### PR TITLE
Add simple VS Code extension for Codex

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,0 +1,5 @@
+# Codex VS Code Extension
+
+This extension adds a command to run the Codex CLI from VS Code. Activate the command **Codex: Run Prompt** from the Command Palette and provide a prompt. Codex will run in a new terminal session.
+
+The extension relies on the `@openai/codex` package from this workspace and spawns `npx codex` inside the terminal.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "codex-vscode-extension",
+  "displayName": "Codex Integration",
+  "description": "Run OpenAI Codex from VS Code",
+  "version": "0.0.1",
+  "publisher": "openai",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onCommand:codex.prompt"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "codex.prompt",
+        "title": "Codex: Run Prompt"
+      }
+    ]
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "build": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/node": "^18",
+    "typescript": "^5.3.3",
+    "vscode": "^1.1.41"
+  },
+  "dependencies": {
+    "@openai/codex": "workspace:*"
+  }
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('codex.prompt', async () => {
+    const prompt = await vscode.window.showInputBox({
+      prompt: 'Enter a prompt for Codex',
+    });
+
+    if (!prompt) {
+      return;
+    }
+
+    const terminal = vscode.window.createTerminal({ name: 'Codex' });
+    terminal.show(true);
+    const escaped = prompt.replace(/"/g, '\\"');
+    terminal.sendText(`npx codex "${escaped}"`);
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "out",
+    "lib": ["es2020"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- create a new `vscode` package providing a VS Code extension
- add command that spawns `npx codex` in a terminal

## Testing
- `pnpm --filter @openai/codex run test` *(fails: unable to download pnpm)*
- `npx tsc -p packages/vscode` *(fails: cannot find module 'vscode')*

------
https://chatgpt.com/codex/tasks/task_e_68422e24f14c83329395d3b9018164fc