### PR TITLE
Add offline setup helper

### DIFF
--- a/PNPM.md
+++ b/PNPM.md
@@ -22,6 +22,16 @@ corepack enable
 corepack prepare pnpm@10.8.1 --activate
 ```
 
+### Offline installs
+
+Use the `scripts/setup-offline.sh` helper to pre-fetch dependencies and install
+without a network connection:
+
+```bash
+scripts/setup-offline.sh --download-only  # fetch packages
+scripts/setup-offline.sh                  # install offline
+```
+
 ### Common commands
 
 | npm command     | pnpm equivalent  |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [Tracing / verbose logging](#tracing--verbose-logging)
 - [Recipes](#recipes)
 - [Installation](#installation)
+- [Offline setup](#offline-setup)
 - [Configuration guide](#configuration-guide)
   - [Basic configuration parameters](#basic-configuration-parameters)
   - [Custom AI provider configuration](#custom-ai-provider-configuration)
@@ -324,6 +325,23 @@ pnpm link
 ```
 
 </details>
+
+## Offline setup
+
+If you need to work without internet access, you can prefetch all Node
+dependencies on a networked machine and reuse them elsewhere:
+
+```bash
+# Download dependencies
+scripts/setup-offline.sh --download-only
+
+# Later, install using the cached packages
+scripts/setup-offline.sh
+```
+
+This script installs `pnpm` via `corepack` if needed and runs the required
+workspace installs. The downloaded artifacts can be copied into an offline
+environment for reproducible installs.
 
 ---
 

--- a/scripts/setup-offline.sh
+++ b/scripts/setup-offline.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Install pnpm and install workspace dependencies with optional offline support.
+# Usage:
+#   scripts/setup-offline.sh [--download-only]
+#
+# When called with --download-only, the script runs 'pnpm fetch' for each
+# workspace so dependencies can be pre-fetched on a machine with internet
+# access. Without the flag, it installs the packages using the previously
+# downloaded artifacts (with --offline).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+DOWNLOAD_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --download-only)
+      DOWNLOAD_ONLY=1
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Ensure pnpm is available via corepack
+if ! command -v pnpm >/dev/null 2>&1; then
+  if command -v corepack >/dev/null 2>&1; then
+    corepack enable >/dev/null
+    corepack prepare pnpm@10.8.1 --activate >/dev/null
+  else
+    echo "pnpm not found and corepack is unavailable. Please install pnpm." >&2
+    exit 1
+  fi
+fi
+
+CMD="install"
+ARGS=(--offline)
+if [[ "$DOWNLOAD_ONLY" -eq 1 ]]; then
+  CMD="fetch"
+  ARGS=()
+fi
+
+# Run the command in the repo root first
+pnpm "$CMD" "${ARGS[@]}"
+
+# Extract workspace directories from pnpm-workspace.yaml
+mapfile -t WORKSPACES < <(grep '^  - ' pnpm-workspace.yaml | sed 's/^  - //')
+
+for pattern in "${WORKSPACES[@]}"; do
+  for dir in $pattern; do
+    if [[ -d "$dir" ]]; then
+      echo "Running pnpm $CMD in $dir"
+      (cd "$dir" && pnpm "$CMD" "${ARGS[@]}")
+    fi
+  done
+done
+


### PR DESCRIPTION
## Summary
- add `scripts/setup-offline.sh` for offline installs and dependency prefetching
- document offline workflow in README and reference script in PNPM docs

## Testing
- `./scripts/asciicheck.py README.md`
- `python3 scripts/readme_toc.py README.md`
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68425130bdb083328132a38a636e7e56