### PR TITLE
Replace extension recipes with command list

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,5 +1,13 @@
 # Codex VS Code Extension
 
-This extension adds a command to run the Codex CLI from VS Code. Activate the command **Codex: Run Prompt** from the Command Palette and pick from several built-in recipes or provide your own prompt. Codex will run in a new terminal session.
+This extension adds a command to run the Codex CLI from VS Code. Activate the command **Codex: Run Prompt** from the Command Palette and pick from several built-in commands or provide your own prompt. Codex will run in a new terminal session.
+
+The default command list includes:
+
+- Explain codebase
+- Refactor code
+- Write unit
+- Write unit tests for code
+- Look for vulnerabilities for code
 
 The extension relies on the `@openai/codex` package from this workspace and spawns `npx codex` inside the terminal.

--- a/packages/vscode/out/extension.js
+++ b/packages/vscode/out/extension.js
@@ -36,23 +36,25 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.activate = activate;
 exports.deactivate = deactivate;
 const vscode = __importStar(require("vscode"));
-const recipes = [
-    'Explain this codebase to me',
-    'Create the fanciest todo-list app',
-    'Refactor the Dashboard component to React Hooks',
-    'Generate SQL migrations for adding a users table',
-    'Write unit tests for utils/date.ts',
-    'Bulk-rename *.jpeg -> *.jpg with git mv',
-    'Explain what this regex does: ^(?=.*[A-Z]).{8,}$',
-    'Carefully review this repo, and propose 3 high impact well-scoped PRs',
-    'Look for vulnerabilities and create a security review report',
-];
+const fs = __importStar(require("fs"));
+const path = __importStar(require("path"));
+function getCommands(extensionPath) {
+    try {
+        const pkgJsonPath = path.join(extensionPath, 'package.json');
+        const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+        return Array.isArray(pkg.codexCommands) ? pkg.codexCommands : [];
+    }
+    catch (_a) {
+        return [];
+    }
+}
 function activate(context) {
+    const commands = getCommands(context.extensionPath);
     const disposable = vscode.commands.registerCommand('codex.prompt', async () => {
-        const items = recipes.map((r) => ({ label: r }));
+        const items = commands.map((c) => ({ label: c }));
         items.push({ label: 'Custom prompt...' });
         const selection = await vscode.window.showQuickPick(items, {
-            placeHolder: 'Select a recipe or enter a custom prompt',
+            placeHolder: 'Select a command or enter a custom prompt',
         });
         if (!selection) {
             return;

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -32,5 +32,12 @@
   },
   "dependencies": {
     "@openai/codex": "workspace:*"
-  }
+  },
+  "codexCommands": [
+    "Explain codebase",
+    "Refactor code",
+    "Write unit",
+    "Write unit tests for code",
+    "Look for vulnerabilities for code"
+  ]
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,24 +1,25 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 
-const recipes = [
-  'Explain this codebase to me',
-  'Create the fanciest todo-list app',
-  'Refactor the Dashboard component to React Hooks',
-  'Generate SQL migrations for adding a users table',
-  'Write unit tests for utils/date.ts',
-  'Bulk-rename *.jpeg -> *.jpg with git mv',
-  'Explain what this regex does: ^(?=.*[A-Z]).{8,}$',
-  'Carefully review this repo, and propose 3 high impact well-scoped PRs',
-  'Look for vulnerabilities and create a security review report',
-];
+function getCommands(extensionPath: string): string[] {
+  try {
+    const pkgJsonPath = path.join(extensionPath, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    return Array.isArray(pkg.codexCommands) ? pkg.codexCommands : [];
+  } catch {
+    return [];
+  }
+}
 
 export function activate(context: vscode.ExtensionContext) {
+  const commands = getCommands(context.extensionPath);
   const disposable = vscode.commands.registerCommand('codex.prompt', async () => {
-    const items: vscode.QuickPickItem[] = recipes.map((r) => ({ label: r }));
+    const items: vscode.QuickPickItem[] = commands.map((c) => ({ label: c }));
     items.push({ label: 'Custom prompt...' });
 
     const selection = await vscode.window.showQuickPick(items, {
-      placeHolder: 'Select a recipe or enter a custom prompt',
+      placeHolder: 'Select a command or enter a custom prompt',
     });
 
     if (!selection) {


### PR DESCRIPTION
## Summary
- expose built-in Codex commands in VSCode `package.json`
- load commands from `package.json` in the extension
- update built JS and README references
- list the default commands in `README.md`
- remove pnpm commands from command list

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm run typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684267360fa48332a879a0821a036feb