### PR TITLE
Update VSCode README with CLI install steps

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -11,3 +11,28 @@ The default command list includes:
 - Look for vulnerabilities for code
 
 The extension relies on the `@openai/codex` package from this workspace and spawns `npx codex` inside the terminal.
+
+## Installing the Codex CLI
+
+1. Install **Node.js 22 or newer** from [nodejs.org](https://nodejs.org/) if you don't already have it.
+2. Install Codex globally:
+
+   ```bash
+   npm install -g @openai/codex
+   ```
+
+3. Set your OpenAI API key as an environment variable:
+
+   ```bash
+   export OPENAI_API_KEY="your-api-key-here"
+   ```
+
+   You can also place this key in a `.env` file at your project root and Codex will load it automatically.
+
+## Using Codex in VS Code
+
+1. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
+2. Choose **Codex: Run Prompt**.
+3. Pick one of the default prompts or select **Custom prompt...** to type your own.
+4. A new terminal will appear running `codex` with your prompt. Follow the CLI instructions to apply or discard the suggested changes.
+


### PR DESCRIPTION
## Summary
- expand VS Code extension README with instructions to install Codex CLI
- outline how to run the CLI from VS Code

## Testing
- `pnpm lint` *(fails: ESLint config not found)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842711cae908332938e883ab8c2e98a