### PR TITLE
Fix VS Code extension tsconfig

### DIFF
--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -7,7 +7,10 @@
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "types": ["node", "vscode"],
+    "skipLibCheck": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add node and vscode typings so the extension compiles

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68427de29974833293f4792ccba076f9