### PR TITLE
Improve Windows sandbox error

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,14 @@ Codex runs model-generated commands in a sandbox. If a proposed command or file 
 <summary>Does it work on Windows?</summary>
 
 Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) - Codex has been tested on macOS and Linux with Node 22.
+Running the CLI outside of WSL2 will fail with an error like:
+
+```
+Error: Sandbox was mandated, but no sandbox is available!
+```
+
+Start a WSL2 shell (or set `CODEX_UNSAFE_ALLOW_NO_SANDBOX=1` if you understand the
+risks) before running `codex` on Windows.
 
 </details>
 

--- a/codex-cli/src/utils/agent/handle-exec-command.ts
+++ b/codex-cli/src/utils/agent/handle-exec-command.ts
@@ -313,6 +313,13 @@ async function getSandbox(runInSandbox: boolean): Promise<SandboxType> {
       // using Landlock in a Linux Docker container from a macOS host may not
       // work.
       return SandboxType.LINUX_LANDLOCK;
+    } else if (process.platform === "win32") {
+      // Windows is supported via WSL2 only. Users running directly on
+      // Windows will see this error.
+      throw new Error(
+        "Codex CLI requires WSL2 on Windows. Please run inside WSL2 or set " +
+          "CODEX_UNSAFE_ALLOW_NO_SANDBOX=1 to override.",
+      );
     } else if (CODEX_UNSAFE_ALLOW_NO_SANDBOX) {
       // Allow running without a sandbox if the user has explicitly marked the
       // environment as already being sufficiently locked-down.


### PR DESCRIPTION
## Summary
- guide Windows users in README
- provide specific error for non-WSL Windows runs

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68563de40834833286ebc6d251eebba2